### PR TITLE
fix: correct order number gender logic and add null order tests

### DIFF
--- a/src/lib/SSINGeneratorHelper.test.ts
+++ b/src/lib/SSINGeneratorHelper.test.ts
@@ -57,4 +57,29 @@ describe('SSIN Generator Helper', () => {
     expect(ssin).toBe('40000095579');
     expect(SSINValidatorHelper.isValid(ssin)).toBe(true);
   });
+
+  it('should generate a valid SSIN when order is null', () => {
+    const birthDate = LocalDate.of(1985, 6, 15);
+    const gender = Gender.MALE;
+    const ssin = SSINGeneratorHelper.generate(birthDate, gender, null, Type.REGULAR);
+    expect(SSINValidatorHelper.isValid(ssin)).toBe(true);
+  });
+
+  it('should generate an odd order number for male when order is null', () => {
+    const birthDate = LocalDate.of(1985, 6, 15);
+    const gender = Gender.MALE;
+    const ssin = SSINGeneratorHelper.generate(birthDate, gender, null, Type.REGULAR);
+    const orderNumber = parseInt(ssin.substring(6, 9), 10);
+    expect(orderNumber % 2).toBe(1);
+  });
+
+  it('should generate an even order number for female when order is null', () => {
+    const birthDate = LocalDate.of(1985, 6, 15);
+    const gender = Gender.FEMALE;
+    const ssin = SSINGeneratorHelper.generate(birthDate, gender, null, Type.REGULAR);
+    console.log(ssin)
+
+    const orderNumber = parseInt(ssin.substring(6, 9), 10);
+    expect(orderNumber % 2).toBe(0);
+  });
 });

--- a/src/lib/SSINGeneratorHelper.test.ts
+++ b/src/lib/SSINGeneratorHelper.test.ts
@@ -77,8 +77,6 @@ describe('SSIN Generator Helper', () => {
     const birthDate = LocalDate.of(1985, 6, 15);
     const gender = Gender.FEMALE;
     const ssin = SSINGeneratorHelper.generate(birthDate, gender, null, Type.REGULAR);
-    console.log(ssin)
-
     const orderNumber = parseInt(ssin.substring(6, 9), 10);
     expect(orderNumber % 2).toBe(0);
   });

--- a/src/lib/SSINGeneratorHelper.ts
+++ b/src/lib/SSINGeneratorHelper.ts
@@ -60,8 +60,8 @@ export class SSINGeneratorHelper {
       order = Math.floor(Math.random() * 999) + 1;
     } else {
       order = 1 + Math.floor(Math.random() * 499) * 2;
-      if (gender === Gender.MALE) {
-        order--;
+      if (gender === Gender.FEMALE) {
+        order++;
       }
     }
     return order.toString().padStart(3, '0');


### PR DESCRIPTION
- Fix bug where order numbers were inverted for gender: males were getting even numbers and females odd numbers, should be odd for males and even for females
- Add test for generating valid SSIN when order is null
- Add test verifying males get odd order numbers
- Add test verifying females get even order numbers